### PR TITLE
chore: remove js chunk splitting from webpack config

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -113,16 +113,6 @@ module.exports = (env, argv) => {
         }),
         new OptimizeCSSAssetsPlugin({}),
       ],
-      runtimeChunk: 'single',
-      splitChunks: {
-        cacheGroups: {
-          vendor: {
-            test: /[\\/]node_modules[\\/]/,
-            name: 'vendors',
-            chunks: 'all',
-          },
-        },
-      },
     },
   };
 };


### PR DESCRIPTION
There's not much application JavaScript code, so this only increases
the number of HTTP requests for no good reason.